### PR TITLE
st7735::clear: dc pin can be set only once

### DIFF
--- a/st7735/src/blocking.rs
+++ b/st7735/src/blocking.rs
@@ -95,15 +95,20 @@ impl<SPEC: DisplaySpec, SPI: embedded_hal::spi::SpiDevice, DC: OutputPin> ST7735
         self.send_command_data(cmds::RAMWR, data)?;
         Ok(())
     }
-
-    fn send_command(&mut self, cmd: u8) -> Result<(), Error<SPI::Error>> {
+    fn begin_command(&mut self) {
         let _ = self.dc.set_low();
+    }
+    fn begin_data(&mut self) {
+        let _ = self.dc.set_high();
+    }
+    fn send_command(&mut self, cmd: u8) -> Result<(), Error<SPI::Error>> {
+        self.begin_command();
         self.spi.write(&[cmd])?;
         Ok(())
     }
 
     fn send_data(&mut self, data: &[u8]) -> Result<(), Error<SPI::Error>> {
-        let _ = self.dc.set_high();
+        self.begin_data();
         self.spi.write(data)?;
         Ok(())
     }
@@ -143,8 +148,10 @@ impl<SPEC: DisplaySpec, SPI: embedded_hal::spi::SpiDevice, DC: OutputPin> DrawTa
         self.set_update_window(0, 0, SPEC::WIDTH, SPEC::HEIGHT)?;
 
         self.send_command(cmds::RAMWR)?;
+        
+        self.begin_data();
         for _ in 0..(SPEC::WIDTH * SPEC::HEIGHT) {
-            self.send_data(color.to_be_bytes().as_ref())?;
+            self.spi.write(color.to_be_bytes().as_ref())?;
         }
         Ok(())
     }


### PR DESCRIPTION
Previously `clear() `  executed dc.set_high() for each pixel