### PR TITLE
sht20: fix compiler warnings

### DIFF
--- a/sht20/src/blocking.rs
+++ b/sht20/src/blocking.rs
@@ -20,7 +20,7 @@ impl<I2C: embedded_hal::i2c::I2c> SHT20<I2C> {
     pub fn set_resolution(&mut self, resolution: Resolution) {
         self.resolution = resolution;
 
-        let mut bits = (resolution as u8);
+        let mut bits = resolution as u8;
         bits = bits | 0b10; // disable on-chip heater, enable OTP reload
 
         self.i2c.write(self.addr, &[cmds::WRITE_REG, bits]).unwrap();

--- a/sht20/src/lib.rs
+++ b/sht20/src/lib.rs
@@ -59,7 +59,7 @@ impl<I2C: embedded_hal_async::i2c::I2c> SHT20<I2C> {
     pub async fn set_resolution(&mut self, resolution: Resolution) -> Result<(), Error<I2C::Error>> {
         self.resolution = resolution;
 
-        let mut bits = (resolution as u8);
+        let mut bits = resolution as u8;
         bits = bits | 0b10; // disable on-chip heater, enable OTP reload
 
         self.i2c.write(self.addr, &[cmds::WRITE_REG, bits]).await?;
@@ -71,7 +71,7 @@ impl<I2C: embedded_hal_async::i2c::I2c> SHT20<I2C> {
         let mut buf = [0u8; 3];
         self.i2c.write(self.addr, &[cmds::TEMP_HOLD]).await?;
 
-        delay.delay_ms(100);
+        delay.delay_ms(100).await;
 
         self.i2c.read(self.addr, &mut buf).await?;
 
@@ -85,7 +85,7 @@ impl<I2C: embedded_hal_async::i2c::I2c> SHT20<I2C> {
     pub async fn read_humidity(&mut self, mut delay: impl DelayNs) -> Result<f32, Error<I2C::Error>> {
         let mut buf = [0u8; 3];
         self.i2c.write(self.addr, &[cmds::HUM_HOLD]).await?;
-        delay.delay_ms(40);
+        delay.delay_ms(40).await;
         self.i2c.read(self.addr, &mut buf).await?;
 
         let raw = u16::from_be_bytes([buf[0], buf[1]]);


### PR DESCRIPTION
fixed warnings:
```
warning: unnecessary parentheses around assigned value
  --> sht20/src/blocking.rs:23:24
   |
23 |         let mut bits = (resolution as u8);
   |                        ^                ^
   |
   = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
   |
23 -         let mut bits = (resolution as u8);
23 +         let mut bits = resolution as u8;
   |

warning: unnecessary parentheses around assigned value
  --> sht20/src/lib.rs:62:24
   |
62 |         let mut bits = (resolution as u8);
   |                        ^                ^
   |
help: remove these parentheses
   |
62 -         let mut bits = (resolution as u8);
62 +         let mut bits = resolution as u8;
   |

   Compiling edrv-adxl345 v0.0.1 (/home/jdr/git/embedded-drivers/adxl345)
warning: unused implementer of `Future` that must be used
  --> sht20/src/lib.rs:74:9
   |
74 |         delay.delay_ms(100);
   |         ^^^^^^^^^^^^^^^^^^^
   |
   = note: futures do nothing unless you `.await` or poll them
   = note: `#[warn(unused_must_use)]` on by default

warning: unused implementer of `Future` that must be used
  --> sht20/src/lib.rs:88:9
   |
88 |         delay.delay_ms(40);
   |         ^^^^^^^^^^^^^^^^^^
   |
   = note: futures do nothing unless you `.await` or poll them

```